### PR TITLE
Fix ShardSim free indices array

### DIFF
--- a/scripts/shards/ShardSim.gd
+++ b/scripts/shards/ShardSim.gd
@@ -21,7 +21,7 @@ var states: PackedInt32Array = PackedInt32Array()
 var carried_by: PackedInt32Array = PackedInt32Array()
 
 var _active_count: int = 0
-var _free_indices: PackedInt32Array = PackedInt32Array()
+var _free_indices: Array[int] = []
 var _rng := RandomNumberGenerator.new()
 var _spatial_hash: SpatialHash = SpatialHash.new()
 var _hash_indices: Array[int] = []
@@ -52,7 +52,7 @@ func clear() -> void:
     states = PackedInt32Array()
     carried_by = PackedInt32Array()
     _active_count = 0
-    _free_indices = PackedInt32Array()
+    _free_indices = []
     _spatial_hash.clear()
     _catapult_cooldowns.clear()
 


### PR DESCRIPTION
## Summary
- switch ShardSim's free index tracking from PackedInt32Array to a standard Array[int]
- reset the free index list correctly when clearing the simulation state

## Testing
- not run (Godot executable not available in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dc6714ca5083269f27a1db97a23ca1