### PR TITLE
Fix MultiMesh color format for Godot 4

### DIFF
--- a/scripts/shards/ShardRenderer.gd
+++ b/scripts/shards/ShardRenderer.gd
@@ -14,7 +14,7 @@ func _ready() -> void:
         add_child(multimesh_instance)
     _multimesh = MultiMesh.new()
     _multimesh.transform_format = MultiMesh.TRANSFORM_2D
-    _multimesh.color_format = MultiMesh.COLOR_8BIT
+    _multimesh.color_format = MultiMesh.COLOR_FLOAT
     _multimesh.instance_count = 0
     _multimesh.mesh = _build_circle_mesh()
     multimesh_instance.multimesh = _multimesh


### PR DESCRIPTION
## Summary
- update the shard renderer's MultiMesh color format to use the Godot 4 compatible float color buffer

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc6ae1df3c832689b8ce291db7ce34